### PR TITLE
Use python console formatting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ that include many processing steps.
 
             return Result(ctx.subscription)
 
-.. code:: python
+.. code:: pycon
 
     >>> Subscribe().buy(category_id=1, user_id=1)
     <Subscription object>

--- a/docs/composition.rst
+++ b/docs/composition.rst
@@ -52,7 +52,7 @@ If you want the parent story to provide some context variables, use
 
 You can see final composition in the class result representation:
 
-.. code:: python
+.. code:: pycon
 
     >>> Subscription.buy
     Subscription.buy:
@@ -115,7 +115,7 @@ where these steps come from, constructor or not.
 At this moment, story definition does not know what
 ``find_promo_code`` step should be.
 
-.. code:: python
+.. code:: pycon
 
     >>> Subscription.buy
     Subscription.buy:
@@ -134,7 +134,7 @@ And when we create an instance of the class we will specify this
 explicitly.  Representation of the instance attribute will show us the
 complete story.
 
-.. code:: python
+.. code:: pycon
 
     >>> Subscription(PromoCode().find).buy
     Subscription.buy:
@@ -210,7 +210,7 @@ This way you decouple your business logic from relation mapper models
 or networking library!  There is no more vendor lock on a certain
 framework or database!  Welcome to the good architecture utopia.
 
-.. code:: python
+.. code:: pycon
 
     >>> def load_profile(user_id):
     ...     return Profile.objects.get(user_id=user_id)

--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -106,7 +106,7 @@ The first run
 
 Looks good at the first view.  Isn't it?  Let's try to run this code.
 
-.. code:: python
+.. code:: pycon
 
     >>> from example import *
     >>> promo_code = ApplyPromoCode(load_category, load_promo_code)
@@ -238,7 +238,7 @@ Let's fix it.
 
 And re-run our program.
 
-.. code:: python
+.. code:: pycon
 
     >>> from example import *
     >>> promo_code = ApplyPromoCode(load_category, load_promo_code)

--- a/docs/execution.rst
+++ b/docs/execution.rst
@@ -49,7 +49,7 @@ continues from the next step.
             print("three")
             return Success()
 
-.. code:: python
+.. code:: pycon
 
     >>> Action().do()
     one
@@ -97,7 +97,7 @@ in the next method of the parent story.
             print("four")
             return Success()
 
-.. code:: python
+.. code:: pycon
 
     >>> Action().do()
     one
@@ -129,7 +129,7 @@ variables for future methods.
             print(ctx.var_b)
             return Success()
 
-.. code:: python
+.. code:: pycon
 
     >>> Action().do()
     1
@@ -162,7 +162,7 @@ failed.  Execution stops at this point.
             print("two")
             return Success()
 
-.. code:: python
+.. code:: pycon
 
     >>> Action().do()
     one
@@ -216,7 +216,7 @@ failed.  Execution stops at this point.
             print("four")
             return Success()
 
-.. code:: python
+.. code:: pycon
 
     >>> Action().do()
     one
@@ -267,7 +267,7 @@ be the return value of the story call.
             print("three")
             return Success()
 
-.. code:: python
+.. code:: pycon
 
     >>> res = Action().do()
     one
@@ -316,7 +316,7 @@ The execution stops after the method returned ``Result``.
             print("four")
             return Success()
 
-.. code:: python
+.. code:: pycon
 
     >>> result = Action().do()
     one
@@ -369,7 +369,7 @@ continued form the next method of the caller story.
             print("four")
             return Success()
 
-.. code:: python
+.. code:: pycon
 
     >>> Action().do()
     one
@@ -399,7 +399,7 @@ If the topmost story returns ``Skip`` result, execution will end.
             print("two")
             return Success()
 
-.. code:: python
+.. code:: pycon
 
     >>> Action().do()
     one

--- a/docs/failure_protocol.rst
+++ b/docs/failure_protocol.rst
@@ -74,7 +74,7 @@ allowed strings.
 Now you can use these string literals to process different failures in
 a different way.
 
-.. code:: python
+.. code:: pycon
 
     >>> promo_code = ApplyPromoCode()
     >>> result = promo_code.apply.run(category=Category(177))
@@ -144,7 +144,7 @@ On Python 2 you can use `enum34`_ package::
 Now you can use `enum`_ members to process different failures in a
 different way.
 
-.. code:: python
+.. code:: pycon
 
     >>> promo_code = ApplyPromoCode()
     >>> result = promo_code.apply.run(category=Category(177))
@@ -239,7 +239,7 @@ A composition of these two stories can fail both because of
 ``failures`` property will contain protocols composition.  A new
 ``enum`` class.
 
-.. code:: python
+.. code:: pycon
 
     >>> buy_subscription = Subscription(PromoCode().find).buy
     >>> result = buy_subscription.run()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -102,7 +102,7 @@ that include many processing steps.
 
             return Result(ctx.subscription)
 
-.. code:: python
+.. code:: pycon
 
     >>> Subscribe().buy(category_id=1, user_id=1)
     <Subscription object>

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -14,7 +14,7 @@ method.
 Result
 ------
 
-.. code:: python
+.. code:: pycon
 
     >>> Subscription().buy(category_id=1, price_id=1, user_id=1)
     <Category: Category object (1)>
@@ -26,7 +26,7 @@ The story was executed successfully.  It returns an object we put into
 Failure
 -------
 
-.. code:: python
+.. code:: pycon
 
     >>> Subscription().buy(category_id=2, price_id=2, user_id=1)
     Traceback (most recent call last):
@@ -56,7 +56,7 @@ summary of the business object execution.
 Result
 ------
 
-.. code:: python
+.. code:: pycon
 
     >>> result = ShowCategory().show.run(category_id=1, user_id=1)
     >>> result.is_success
@@ -71,7 +71,7 @@ available in the ``value`` attribute.
 Failure
 -------
 
-.. code:: python
+.. code:: pycon
 
     >>> result = ShowCategory().show.run(category_id=2, user_id=1)
     >>> result.is_failure


### PR DESCRIPTION
When demonstrating console output, use the pycon formatter to format console output correctly.

The only place I haven't used it is when pdb was involved since it didn't parse it correctly.