### PR TITLE
issue #222 - fix behavior of Context.__getattr__

### DIFF
--- a/src/stories/_context.py
+++ b/src/stories/_context.py
@@ -1,8 +1,18 @@
+import textwrap
 from collections import OrderedDict
 from decimal import Decimal
 
 from ._compat import indent
 from .exceptions import MutationError
+
+
+ATTRIBUTE_ERROR_MSG = textwrap.dedent(
+    """
+    '{obj}' object has no attribute {attr}
+
+    {ctx!r}
+    """
+).strip()
 
 
 def make_context(contract, kwargs, history):
@@ -22,7 +32,12 @@ def make_context(contract, kwargs, history):
 
 class Context(object):
     def __getattr__(self, name):
-        return self.__ns[name]
+        try:
+            return self.__ns[name]
+        except KeyError:
+            raise AttributeError(
+                ATTRIBUTE_ERROR_MSG.format(obj="Context", attr=name, ctx=self)
+            )
 
     def __setattr__(self, name, value):
         raise MutationError(assign_attribute_message)

--- a/tests/helpers/examples/methods.py
+++ b/tests/helpers/examples/methods.py
@@ -75,6 +75,31 @@ class Pipe(object):
         raise Exception()
 
 
+class Branch(object):
+    @story
+    @arguments("age")
+    def show_content(I):
+        I.age_lt_18
+        I.age_gte_18
+        I.load_content
+
+    def age_lt_18(self, ctx):
+        if ctx.age < 18:
+            return Success(access_allowed=False)
+        return Success()
+
+    def age_gte_18(self, ctx):
+        if not hasattr(ctx, "access_allowed") and ctx.age >= 18:
+            return Success(access_allowed=True)
+        return Success()
+
+    def load_content(self, ctx):
+        if ctx.access_allowed:
+            return Result("allowed")
+        else:
+            return Result("denied")
+
+
 # Substory in the same class.
 
 
@@ -169,3 +194,15 @@ class StepError(object):
 
     def one(self, ctx):
         raise Exception()
+
+
+# Access non-existent context attribute.
+
+
+class AttributeAccessError(object):
+    @story
+    def x(I):
+        I.one
+
+    def one(self, ctx):
+        ctx.x

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -263,6 +263,53 @@ Context:
     assert repr(getter()) == expected
 
 
+def test_context_proper_getattr_behavior():
+    expected = """
+Branch.show_content
+  age_lt_18
+  age_gte_18
+  load_content (returned: 'allowed')
+
+Context:
+  age: 18               # Story argument
+  access_allowed: True  # Set by Branch.age_gte_18
+    """.strip()
+    getter = make_collector()
+    examples.methods.Branch().show_content(age=18)
+    result = repr(getter())
+    assert result == expected
+
+    expected = """
+Branch.show_content
+  age_lt_18
+  age_gte_18
+  load_content (returned: 'denied')
+
+Context:
+  age: 1                 # Story argument
+  access_allowed: False  # Set by Branch.age_lt_18
+    """.strip()
+    getter = make_collector()
+    examples.methods.Branch().show_content(age=1)
+    result = repr(getter())
+    assert result == expected
+
+
+def test_context_attribute_error():
+    expected = """
+'Context' object has no attribute x
+
+AttributeAccessError.x
+  one
+
+Context()
+    """.strip()
+    with pytest.raises(AttributeError) as err:
+        examples.methods.AttributeAccessError().x()
+    result = str(err.value)
+    assert result == expected
+
+
 def test_context_representation_with_failure():
 
     expected = """


### PR DESCRIPTION
Before this commit, `Context.__getattr__` raise `KeyError` in case the attribute
was not found, but this type of exception violates the contract described in the
official Python documentation. According to the documentation, `AttributeError`
is expected.