### PR TITLE
Parallelize tests to shorten CI runtime

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ deps =
   pytest-azurepipelines
   pytest-randomly
   pytest-timeout
+  pytest-xdist
   PyYAML
   raven
   tomlkit
@@ -48,7 +49,7 @@ setenv =
   DJANGO_SETTINGS_MODULE = django_project.settings
 commands =
   pip install ./tests/helpers/.
-  coverage run -m pytest {posargs}
+  coverage run -m pytest -n auto {posargs}
 
 [testenv:flake8]
 basepython = python3.8


### PR DESCRIPTION
I've tested locally and it seems that we can cut at least a second by parallelizing the tests.
I'm testing it in CI to see if we get the same results.