### PR TITLE
style: fix new flake8-pytest errors

### DIFF
--- a/tests/helpers/examples/methods/__init__.py
+++ b/tests/helpers/examples/methods/__init__.py
@@ -22,3 +22,7 @@ class Parent(object):
         I.before
         I.x
         I.after
+
+
+class ExpectedException(Exception):
+    pass

--- a/tests/helpers/examples/methods/coroutines.py
+++ b/tests/helpers/examples/methods/coroutines.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
-from examples.methods import *  # noqa: F401, F403
+from examples.methods import *  # noqa: F403
 from stories import arguments
 from stories import Failure
 from stories import Result
 from stories import Skip
 from stories import story
 from stories import Success
-
 
 # Mixins.
 
@@ -258,7 +257,7 @@ class StepError(object):
         I.one
 
     async def one(self, ctx):
-        raise Exception()
+        raise ExpectedException()  # noqa: F405
 
 
 # Access non-existent context attribute.

--- a/tests/helpers/examples/methods/functions.py
+++ b/tests/helpers/examples/methods/functions.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
-from examples.methods import *  # noqa: F401, F403
+from examples.methods import *  # noqa: F403
 from stories import arguments
 from stories import Failure
 from stories import Result
 from stories import Skip
 from stories import story
 from stories import Success
-
 
 # Mixins.
 
@@ -207,7 +206,7 @@ class StepError(object):
         I.one
 
     def one(self, ctx):
-        raise Exception()
+        raise ExpectedException()  # noqa: F405
 
 
 # Access non-existent context attribute.

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -679,18 +679,18 @@ def test_context_representation_with_error(r, x):
 
     expected = """
 StepError.x
-  one (errored: Exception)
+  one (errored: ExpectedException)
 
 Context()
     """.strip()
 
     getter = make_collector()
-    with pytest.raises(Exception):
+    with pytest.raises(x.ExpectedException):
         r(x.StepError().x)()
     assert repr(getter()) == expected
 
     getter = make_collector()
-    with pytest.raises(Exception):
+    with pytest.raises(x.ExpectedException):
         r(x.StepError().x.run)()
     assert repr(getter()) == expected
 


### PR DESCRIPTION
Master is failing because of new rules in flkae8-pytest.
This PR fixes those errors.