### PR TITLE
Simplify condition checking all argument names are strings

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -7,28 +7,28 @@ module.exports = {
     [
       "@semantic-release/changelog",
       {
-        changelogFile: "docs/changelog.md"
-      }
+        changelogFile: "docs/changelog.md",
+      },
     ],
     [
       "@semantic-release/exec",
       {
         prepareCmd:
           "tox -e precommit -- --files docs/changelog.md ; poetry version ${nextRelease.version} && poetry build",
-        publishCmd: "poetry publish"
-      }
+        publishCmd: "poetry publish",
+      },
     ],
     [
       "@semantic-release/git",
       {
-        assets: ["docs/changelog.md", "pyproject.toml"]
-      }
+        assets: ["docs/changelog.md", "pyproject.toml"],
+      },
     ],
     [
       "@semantic-release/github",
       {
-        assets: [{ path: "dist/*.whl" }, { path: "dist/*.tar.gz" }]
-      }
-    ]
-  ]
+        assets: [{ path: "dist/*.whl" }, { path: "dist/*.tar.gz" }],
+      },
+    ],
+  ],
 };

--- a/src/_stories/argument.py
+++ b/src/_stories/argument.py
@@ -6,7 +6,7 @@ def arguments(*names):
     if not names:
         raise StoryDefinitionError("Story arguments can not be an empty list")
 
-    if any(name for name in names if not isinstance(name, str)):
+    if not all(isinstance(name, str) for name in names):
         message = "Story arguments can only be defined with string type"
         raise StoryDefinitionError(message)
 


### PR DESCRIPTION
It's easier to read and requires to execute less conditions so startup time will be slightly faster, especially if you have a lot of stories.