### PR TITLE
Improve error message when returning an invalid result type

### DIFF
--- a/src/_stories/execute/coroutine.py
+++ b/src/_stories/execute/coroutine.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
+from _stories.execute.utilities import validate_result_type
 from _stories.marker import BeginningOfStory
 from _stories.marker import EndOfStory
 from _stories.returned import Failure
 from _stories.returned import Result
 from _stories.returned import Skip
-from _stories.returned import Success
 
 
 async def execute(runner, ctx, ns, bind, history, methods):
@@ -46,8 +46,7 @@ async def execute(runner, ctx, ns, bind, history, methods):
             raise
 
         restype = type(result)
-        if restype not in (Result, Success, Failure, Skip):
-            raise AssertionError
+        validate_result_type(method, restype, result)
 
         if restype is Failure:
             try:

--- a/src/_stories/execute/function.py
+++ b/src/_stories/execute/function.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
+from _stories.execute.utilities import validate_result_type
 from _stories.marker import BeginningOfStory
 from _stories.marker import EndOfStory
 from _stories.returned import Failure
 from _stories.returned import Result
 from _stories.returned import Skip
-from _stories.returned import Success
 
 
 def execute(runner, ctx, ns, bind, history, methods):
@@ -46,8 +46,7 @@ def execute(runner, ctx, ns, bind, history, methods):
             raise
 
         restype = type(result)
-        if restype not in (Result, Success, Failure, Skip):
-            raise AssertionError
+        validate_result_type(method, restype, result)
 
         if restype is Failure:
             try:

--- a/src/_stories/execute/utilities.py
+++ b/src/_stories/execute/utilities.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+from _stories.exceptions import StoryDefinitionError
+from _stories.returned import Failure
+from _stories.returned import Result
+from _stories.returned import Skip
+from _stories.returned import Success
+
+
+def validate_result_type(method, result_type, result):
+    if hasattr(method, "story_name"):
+        method_name = "{}.{}".format(method.story_name, method.__name__)
+    else:
+        try:
+            method_name = method.__qualname__
+        except AttributeError:
+            # Python 2 fallback
+            method_name = "{}.{}".format(
+                method.im_self.__class__.__name__, method.__name__
+            )
+    if result_type not in (Result, Success, Failure, Skip):
+        if result is True:
+            expected = "`Success()` or `Result(True)`"
+            raise StoryDefinitionError(
+                ambiguous_result_type_template.format(
+                    method=method_name, result=result, expected=expected
+                )
+            )
+        elif result is False:
+            expected = "`Failure()` or `Result(False)`"
+            raise StoryDefinitionError(
+                ambiguous_result_type_template.format(
+                    method=method_name, result=result, expected=expected
+                )
+            )
+        elif result is None:
+            expected = "`Success()` or `Result()`"
+            raise StoryDefinitionError(
+                ambiguous_result_type_template.format(
+                    method=method_name, result=result, expected=expected
+                )
+            )
+        else:
+            expected = "`Result({})`".format(result)
+            raise StoryDefinitionError(
+                invalid_result_type_template.format(
+                    method=method_name, result=result, expected=expected
+                )
+            )
+
+
+# Messages
+
+ambiguous_result_type_template = """
+Ambiguous result type returned from {method}.
+
+Got `{result}`. Did you mean {expected}?
+""".strip()
+
+invalid_result_type_template = """
+Invalid result type returned from {method}.
+
+Got `{result}`. Did you mean {expected}?
+""".strip()

--- a/tests/helpers/examples/methods/coroutines.py
+++ b/tests/helpers/examples/methods/coroutines.py
@@ -7,6 +7,7 @@ from stories import Skip
 from stories import story
 from stories import Success
 
+
 # Mixins.
 
 
@@ -231,12 +232,31 @@ class SubstoryDI(object):
 
 
 class WrongResult(object):
+    def __init__(self, result, step=None):
+        self.result = result
+        if step is None:
+            self.step = self.one
+        else:
+            self.step = step(result).one
+
+    @story
+    def x(I):
+        I.step
+
+    async def one(self, ctx):
+        return self.result
+
+
+class WrongResultSubStory(object):
+    def __init__(self, result):
+        self.result = result
+
     @story
     def x(I):
         I.one
 
     async def one(self, ctx):
-        return 1
+        return self.result
 
 
 # Dependency injection of the implementation methods.

--- a/tests/helpers/examples/methods/functions.py
+++ b/tests/helpers/examples/methods/functions.py
@@ -7,6 +7,7 @@ from stories import Skip
 from stories import story
 from stories import Success
 
+
 # Mixins.
 
 
@@ -180,12 +181,31 @@ class SubstoryDI(object):
 
 
 class WrongResult(object):
+    def __init__(self, result, step=None):
+        self.result = result
+        if step is None:
+            self.step = self.one
+        else:
+            self.step = step(result).one
+
+    @story
+    def x(I):
+        I.step
+
+    def one(self, ctx):
+        return self.result
+
+
+class WrongResultSubStory(object):
+    def __init__(self, result):
+        self.result = result
+
     @story
     def x(I):
         I.one
 
     def one(self, ctx):
-        return 1
+        return self.result
 
 
 # Dependency injection of the implementation methods.

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+from _stories.exceptions import StoryDefinitionError
 from stories.exceptions import FailureError
 
 
@@ -217,11 +218,117 @@ def test_return_type(r, x):
     Any other value is denied.
     """
 
-    with pytest.raises(AssertionError):
-        r(x.WrongResult().x)()
+    expected = """
+Invalid result type returned from WrongResult.one.
 
-    with pytest.raises(AssertionError):
-        r(x.WrongResult().x.run)()
+Got `1`. Did you mean `Result(1)`?
+""".strip()
+    with pytest.raises(StoryDefinitionError) as exc_info:
+        r(x.WrongResult(1).x)()
+    assert str(exc_info.value) == expected
+
+    with pytest.raises(StoryDefinitionError) as exc_info:
+        r(x.WrongResult(1).x.run)()
+
+    assert str(exc_info.value) == expected
+
+    expected = """
+Ambiguous result type returned from WrongResult.one.
+
+Got `True`. Did you mean `Success()` or `Result(True)`?
+""".strip()
+    with pytest.raises(StoryDefinitionError) as exc_info:
+        r(x.WrongResult(True).x)()
+    assert str(exc_info.value) == expected
+
+    with pytest.raises(StoryDefinitionError) as exc_info:
+        r(x.WrongResult(True).x.run)()
+
+    assert str(exc_info.value) == expected
+
+    expected = """
+Ambiguous result type returned from WrongResult.one.
+
+Got `False`. Did you mean `Failure()` or `Result(False)`?
+""".strip()
+    with pytest.raises(StoryDefinitionError) as exc_info:
+        r(x.WrongResult(False).x)()
+    assert str(exc_info.value) == expected
+
+    with pytest.raises(StoryDefinitionError) as exc_info:
+        r(x.WrongResult(False).x.run)()
+
+    assert str(exc_info.value) == expected
+
+    expected = """
+Ambiguous result type returned from WrongResult.one.
+
+Got `None`. Did you mean `Success()` or `Result()`?
+""".strip()
+    with pytest.raises(StoryDefinitionError) as exc_info:
+        r(x.WrongResult(None).x)()
+    assert str(exc_info.value) == expected
+
+    with pytest.raises(StoryDefinitionError) as exc_info:
+        r(x.WrongResult(None).x.run)()
+
+    assert str(exc_info.value) == expected
+
+    expected = """
+Invalid result type returned from WrongResultSubStory.one.
+
+Got `1`. Did you mean `Result(1)`?
+""".strip()
+    with pytest.raises(StoryDefinitionError) as exc_info:
+        r(x.WrongResult(1, step=x.WrongResultSubStory).x)()
+    assert str(exc_info.value) == expected
+
+    with pytest.raises(StoryDefinitionError) as exc_info:
+        r(x.WrongResult(1, step=x.WrongResultSubStory).x.run)()
+
+    assert str(exc_info.value) == expected
+
+    expected = """
+Ambiguous result type returned from WrongResultSubStory.one.
+
+Got `True`. Did you mean `Success()` or `Result(True)`?
+""".strip()
+    with pytest.raises(StoryDefinitionError) as exc_info:
+        r(x.WrongResult(True, step=x.WrongResultSubStory).x)()
+    assert str(exc_info.value) == expected
+
+    with pytest.raises(StoryDefinitionError) as exc_info:
+        r(x.WrongResult(True, step=x.WrongResultSubStory).x.run)()
+
+    assert str(exc_info.value) == expected
+
+    expected = """
+Ambiguous result type returned from WrongResultSubStory.one.
+
+Got `False`. Did you mean `Failure()` or `Result(False)`?
+""".strip()
+    with pytest.raises(StoryDefinitionError) as exc_info:
+        r(x.WrongResult(False, step=x.WrongResultSubStory).x)()
+    assert str(exc_info.value) == expected
+
+    with pytest.raises(StoryDefinitionError) as exc_info:
+        r(x.WrongResult(False, step=x.WrongResultSubStory).x.run)()
+
+    assert str(exc_info.value) == expected
+
+    expected = """
+Ambiguous result type returned from WrongResultSubStory.one.
+
+Got `None`. Did you mean `Success()` or `Result()`?
+""".strip()
+    with pytest.raises(StoryDefinitionError) as exc_info:
+        r(x.WrongResult(None, step=x.WrongResultSubStory).x)()
+    assert str(exc_info.value) == expected
+
+    with pytest.raises(StoryDefinitionError) as exc_info:
+        r(x.WrongResult(None, step=x.WrongResultSubStory).x.run)()
+
+    assert str(exc_info.value) == expected
 
 
 def test_inject_implementation(r, x):


### PR DESCRIPTION
An assert statement would be removed when running Python with
`-O` and the result of the step will not be recorded in history.
Furthermore, the error had no message which wasn't informative to the users.

This PR modified our executors to raises a proper exception.