### PR TITLE
Run tox jobs in parallel & minor improvements

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
           git checkout master --quiet
           git checkout - --quiet
         displayName: Unshallow commit log.
-      - script: tox
+      - script: TOX_PARALLEL_NO_SPINNER=1 tox -p auto
         displayName: Run Tox.
       - script: codecov
         env:

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ strict = true
 addopts = --full-trace --tb=long --showlocals
 testpaths = tests
 timeout = 5
+junit_family = xunit2

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ addopts = --full-trace --tb=long --showlocals
 testpaths = tests
 timeout = 5
 junit_family = xunit2
+junit_log_passing_tests = true

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ whitelist_externals =
   sed
 
 [testenv]
+parallel_show_output = true
 deps =
   cerberus: Cerberus
   coverage

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ setenv =
   DJANGO_SETTINGS_MODULE = django_project.settings
 commands =
   pip install ./tests/helpers/.
-  coverage run -m pytest {posargs}
+  coverage run -m pytest --test-run-title={envname} {posargs}
 
 [testenv:flake8]
 basepython = python3.8


### PR DESCRIPTION
This allows us to fail the build if the coverage is below 90% per the goal of #351 but should cut build time in half.