### PR TITLE
Support Django 4.0

### DIFF
--- a/src/_stories/contrib/debug_toolbars/django/panels.py
+++ b/src/_stories/contrib/debug_toolbars/django/panels.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 from debug_toolbar.panels import Panel
-from django.utils.translation import ugettext_lazy as _
+
+try:
+    from django.utils.translation import gettext_lazy as _
+except ImportError:
+    from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ungettext_lazy as __
 
 import _stories.context


### PR DESCRIPTION
ugettext_lazy will be removed in Django 4.0.
It is replaced with gettext_lazy.